### PR TITLE
add network role assignment

### DIFF
--- a/Identity/main.bicep
+++ b/Identity/main.bicep
@@ -1,10 +1,11 @@
 //create managed identity
 param location string = resourceGroup().location
+param networkRoleDifinitionName string = guid(subscription().subscriptionId, 'networkRoleAssignment')
 param networkRoleName string = guid(subscription().subscriptionId, 'networkRoleAssignment')
 param managedIdentityName string
 
 resource networkRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' = {
-  name: networkRoleName
+  name: networkRoleDifinitionName
   properties: {
     roleName: 'Network Contributor'
     description: 'Lets you manage networks, but not access to them.'
@@ -14,7 +15,9 @@ resource networkRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-
     permissions: [
       {
         actions: [
-          'Microsoft.Network/*'
+          'icrosoft.Network/virtualNetworks/subnets/join/action'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/validate/action'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/write'
         ]
         notActions: []
       }

--- a/Identity/main.bicep
+++ b/Identity/main.bicep
@@ -1,0 +1,39 @@
+//create managed identity
+param location string = resourceGroup().location
+param networkRoleName string = guid(subscription().subscriptionId, 'networkRoleAssignment')
+param managedIdentityName string
+
+resource networkRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-05-01-preview' = {
+  name: networkRoleName
+  properties: {
+    roleName: 'Network Contributor'
+    description: 'Lets you manage networks, but not access to them.'
+    assignableScopes: [
+      subscription().subscriptionId
+    ]
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Network/*'
+        ]
+        notActions: []
+      }
+    ]
+  }
+}
+
+resource networkRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: networkRoleName
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: networkRoleDefinition.id
+    principalId: managedIdentity.properties.principalId
+  }
+}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-07-31-preview' = {
+  name: managedIdentityName
+  location: location
+}
+
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId


### PR DESCRIPTION
This pull request introduces the creation of a managed identity and assigns a network role to it in the `Identity/main.bicep` file. The most important changes include defining parameters for the managed identity and network role, creating the network role definition and assignment, and outputting the managed identity's principal ID.

Key changes:

* Added parameters for `location`, `networkRoleDifinitionName`, `networkRoleName`, and `managedIdentityName` to define the managed identity and network role.
* Created a `networkRoleDefinition` resource to define the 'Network Contributor' role with specific permissions.
* Created a `networkRoleAssignment` resource to assign the defined network role to the managed identity.
* Created a `managedIdentity` resource to define the user-assigned managed identity.
* Added an output to return the `managedIdentityPrincipalId` of the managed identity.