### PR TITLE
Add Bicep template for Azure Logic App and App Service Plan

### DIFF
--- a/Web/standard/main.bicep
+++ b/Web/standard/main.bicep
@@ -1,0 +1,28 @@
+param logicAppName string
+param location string = resourceGroup().location
+
+var appServicePlanName = '${logicAppName}-asp'
+
+var name = 'WS1'
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: appServicePlanName
+  location: location
+  sku: {
+    name: name
+    tier: 'Standard'
+  }
+  kind: 'functionapp'
+}
+
+resource logicApp 'Microsoft.Logic/integrationAccounts@2019-05-01' = {
+  name: logicAppName
+  location: location
+  properties: {
+    integrationServiceEnvironment: null
+    state: 'Enabled'
+  }
+  sku: {
+    name: 'Standard'
+  }
+}


### PR DESCRIPTION
This pull request introduces new resources to the `Web/standard/main.bicep` file, including the addition of parameters and resources for an App Service Plan and a Logic App. The most important changes are:

* Added new parameters `logicAppName` and `location` with default value set to `resourceGroup().location`.
* Defined a variable `appServicePlanName` to construct the App Service Plan name using the `logicAppName` parameter.
* Introduced a new `appServicePlan` resource of type `Microsoft.Web/serverfarms@2024-04-01` with a `Standard` SKU and `functionapp` kind.
* Added a new `logicApp` resource of type `Microsoft.Logic/integrationAccounts@2019-05-01` with `Standard` SKU and enabled state.